### PR TITLE
Fix default export name for Header component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -278,4 +278,4 @@ const Header = () => {
   );
 };
 
-export default header;
+export default Header;


### PR DESCRIPTION
## Summary
- fix incorrect default export in `Header.tsx`

## Testing
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431e7dc104832ebf5252cd04cbb2f7