### PR TITLE
Revamp site style for credibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+
+    <!-- Google Font: Inter -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -58,7 +58,7 @@ const Header = () => {
   ];
 
   return (
-    <header className="fixed w-full top-0 z-50 bg-purple-700 shadow-sm border-b">
+    <header className="fixed w-full top-0 z-50 bg-white/80 backdrop-blur shadow-md border-b">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
@@ -79,7 +79,7 @@ const Header = () => {
                 key={item.name}
                 onClick={() => navigate(item.href)}
                 className={`relative text-gray-700 hover:text-blue-600 transition-colors font-medium ${
-                  location.pathname === item.href ? "text-blue-600" : ""
+                  location.pathname === item.href ? "text-blue-600 font-semibold" : ""
                 }`}
               >
                 {item.name}
@@ -184,7 +184,7 @@ const Header = () => {
                   }}
                   className={`relative block px-3 py-2 text-base font-medium transition-colors w-full text-left ${
                     location.pathname === item.href
-                      ? "text-blue-600 bg-blue-50"
+                      ? "text-blue-600 font-semibold bg-blue-50"
                       : "text-gray-700 hover:text-blue-600 hover:bg-gray-50"
                   }`}
                 >

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -24,13 +24,12 @@ const HeroSection = () => {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-32">
         <div className="text-center max-w-4xl mx-auto">
           <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 animate-fade-in">
-            Conecte-se com os melhores
-            <span className="block text-gradient">freelancers do setor</span>
+            Conecte-se aos melhores
+            <span className="block text-gradient">profissionais do setor</span>
           </h1>
           
           <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto animate-fade-in" style={{animationDelay: '0.2s'}}>
-            A plataforma que conecta estabelecimentos a garçons, promoters e profissionais de eventos qualificados. 
-            Contrate com agilidade e confiança.
+            Plataforma confiável para contratar garçons, promoters e especialistas em eventos de forma ágil e segura.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12 animate-fade-in" style={{animationDelay: '0.4s'}}>

--- a/src/index.css
+++ b/src/index.css
@@ -90,7 +90,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,8 +18,11 @@ export default {
 				'2xl': '1400px'
 			}
 		},
-		extend: {
-			colors: {
+               extend: {
+                        fontFamily: {
+                                sans: ["Inter", "sans-serif"],
+                        },
+                        colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',


### PR DESCRIPTION
## Summary
- load Inter font in the app
- use Inter as the default Tailwind font
- improve readability of header and navigation
- refine hero section copy for trust

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846efca056c832e9f39244516ba6289