### PR TITLE
Reintroduce original logo with SVG fallback

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,7 +67,12 @@ const Header = () => {
               onClick={() => navigate("/")}
               className="flex items-center text-2xl font-bold text-blue-600 hover:text-blue-700 transition-colors"
             >
-              <img src="/logo.svg" alt="Logo" className="h-26 w-24 mr-4" />
+              <img
+                src="/logo.png"
+                srcSet="/logo.svg 2x"
+                alt="Logo"
+                className="h-26 w-24 mr-4"
+              />
               {user && <span className="text-white font-semibold">{user.name}</span>}
             </button>
           </div>


### PR DESCRIPTION
## Summary
- use the previous `logo.png` in the header
- provide an SVG fallback for higher quality on high‑resolution displays

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f44d0dec832eaa9a944417e0aa10