### PR TITLE
Fix sign-up not storing to Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,6 @@ Install dependencies (including `@supabase/supabase-js`) and run the development
 npm install
 npm run dev
 ```
+
+During registration, new accounts are inserted into the `users` table so make
+sure this table exists in your Supabase project with Row Level Security enabled.

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -45,7 +45,7 @@ const Register = () => {
 
     setIsLoading(true);
 
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email: formData.email,
       password: formData.password,
       options: {
@@ -59,6 +59,25 @@ const Register = () => {
         },
       },
     });
+
+    if (data.user) {
+      const { error: insertError } = await supabase.from("users").insert({
+        id: data.user.id,
+        name: formData.name,
+        email: formData.email,
+        phone: formData.phone,
+        city: formData.city,
+        category: formData.category,
+        description: formData.description,
+        user_type: userType,
+      });
+
+      if (insertError) {
+        toast({ title: "Erro", description: insertError.message, variant: "destructive" });
+        setIsLoading(false);
+        return;
+      }
+    }
 
     if (error) {
       toast({ title: "Erro", description: error.message, variant: "destructive" });


### PR DESCRIPTION
## Summary
- insert new users into the `users` table after registration
- document the table requirement in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684860d9c9b8832e91bdc44e92ff62ae