### PR TITLE
Fix missing profile after email confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ Install dependencies (including `@supabase/supabase-js`) and run the development
 npm install
 npm run dev
 ```
+
+During registration, a profile row is inserted into the `users` table only once
+a session is available. If your project requires e‑mail confirmation, this row
+is created the first time the user signs in. The login page checks for the
+record and inserts it when missing. Ensure the `users` table exists in your
+Supabase project with Row Level Security enabled for authenticated users.

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -42,6 +42,42 @@ const Login = () => {
       email: data.user?.email || email,
     };
 
+    // Ensure a profile row exists for this user
+    if (data.user) {
+      const profileData = {
+        id: data.user.id,
+        name: (data.user.user_metadata as any)?.name ?? "",
+        email: data.user.email ?? email,
+        phone: (data.user.user_metadata as any)?.phone ?? "",
+        city: (data.user.user_metadata as any)?.city ?? "",
+        category: (data.user.user_metadata as any)?.category ?? "",
+        description: (data.user.user_metadata as any)?.description ?? "",
+        user_type: (data.user.user_metadata as any)?.user_type ?? userType,
+      };
+
+      const { data: existing } = await supabase
+        .from("users")
+        .select("id")
+        .eq("id", data.user.id)
+        .single();
+
+      if (!existing) {
+        const { error: insertError } = await supabase
+          .from("users")
+          .insert(profileData);
+
+        if (insertError) {
+          toast({
+            title: "Erro",
+            description: insertError.message,
+            variant: "destructive",
+          });
+          setIsLoading(false);
+          return;
+        }
+      }
+    }
+
     login(userData);
 
     toast({

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -45,7 +45,7 @@ const Register = () => {
 
     setIsLoading(true);
 
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email: formData.email,
       password: formData.password,
       options: {
@@ -60,16 +60,42 @@ const Register = () => {
       },
     });
 
+    if (data.session) {
+      const { error: insertError } = await supabase.from("users").insert({
+        id: data.user.id,
+        name: formData.name,
+        email: formData.email,
+        phone: formData.phone,
+        city: formData.city,
+        category: formData.category,
+        description: formData.description,
+        user_type: userType,
+      });
+
+      if (insertError) {
+        toast({ title: "Erro", description: insertError.message, variant: "destructive" });
+        setIsLoading(false);
+        return;
+      }
+    }
+
     if (error) {
       toast({ title: "Erro", description: error.message, variant: "destructive" });
       setIsLoading(false);
       return;
     }
 
-    toast({
-      title: "Conta criada com sucesso!",
-      description: `Bem-vindo(a) à FreelanceConnect, ${formData.name}!`,
-    });
+    if (data.session) {
+      toast({
+        title: "Conta criada com sucesso!",
+        description: `Bem-vindo(a) à FreelanceConnect, ${formData.name}!`,
+      });
+    } else {
+      toast({
+        title: "Verifique seu e-mail",
+        description: "Clique no link que enviamos para ativar sua conta.",
+      });
+    }
 
     navigate("/login");
     setIsLoading(false);


### PR DESCRIPTION
## Summary
- ensure login creates profile row if it doesn't already exist
- document the automatic creation of the profile row after first sign‑in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684860d9c9b8832e91bdc44e92ff62ae