### PR TITLE
Melhorias na responsividade para mobile

### DIFF
--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -15,11 +15,11 @@ const CTASection = () => {
   };
 
   return (
-    <section className="py-20 bg-gradient-primary relative overflow-hidden">
+    <section className="py-16 sm:py-20 bg-gradient-primary relative overflow-hidden">
       {/* Background decorative elements */}
-      <div className="absolute top-10 left-10 w-20 h-20 bg-white/10 rounded-full"></div>
-      <div className="absolute bottom-10 right-10 w-32 h-32 bg-white/5 rounded-full"></div>
-      <div className="absolute top-1/2 left-1/4 w-16 h-16 bg-white/10 rounded-full"></div>
+      <div className="hidden sm:block absolute top-10 left-10 w-20 h-20 bg-white/10 rounded-full"></div>
+      <div className="hidden sm:block absolute bottom-10 right-10 w-32 h-32 bg-white/5 rounded-full"></div>
+      <div className="hidden sm:block absolute top-1/2 left-1/4 w-16 h-16 bg-white/10 rounded-full"></div>
       
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
         <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white mb-6">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -19,11 +19,11 @@ const HeroSection = () => {
   return (
     <section className="relative min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-white overflow-hidden">
       {/* Background decorative elements */}
-      <div className="absolute top-20 left-10 w-20 h-20 bg-blue-200 rounded-full opacity-50 animate-float"></div>
-      <div className="absolute top-40 right-20 w-16 h-16 bg-purple-200 rounded-full opacity-50 animate-float" style={{animationDelay: '1s'}}></div>
-      <div className="absolute bottom-20 left-1/4 w-12 h-12 bg-indigo-200 rounded-full opacity-50 animate-float" style={{animationDelay: '2s'}}></div>
-      
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-32">
+      <div className="hidden sm:block absolute top-20 left-10 w-20 h-20 bg-blue-200 rounded-full opacity-50 animate-float"></div>
+      <div className="hidden sm:block absolute top-40 right-20 w-16 h-16 bg-purple-200 rounded-full opacity-50 animate-float" style={{animationDelay: '1s'}}></div>
+      <div className="hidden sm:block absolute bottom-20 left-1/4 w-12 h-12 bg-indigo-200 rounded-full opacity-50 animate-float" style={{animationDelay: '2s'}}></div>
+
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 pt-24 sm:pt-32 pb-20 sm:pb-32">
         <div className="text-center max-w-4xl mx-auto">
           <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 animate-fade-in">
             Conecte-se aos melhores

--- a/src/index.css
+++ b/src/index.css
@@ -90,7 +90,7 @@
   }
 
   body {
-    @apply bg-background text-foreground font-sans;
+    @apply bg-background text-foreground font-sans overflow-x-hidden;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }


### PR DESCRIPTION
## Summary
- esconder elementos decorativos das seções Hero e CTA em telas menores
- ajustar espaçamentos nessas seções
- evitar rolagem horizontal adicionando `overflow-x-hidden` ao `body`

## Testing
- `npm run lint` *(falhou: Cannot find package '@eslint/js')*
- `npm run build` *(falhou: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851bb297ab4832eb9e29303ed00bc1f