### PR TITLE
Update branding in header and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FreeAllin</title>
+    <title>GarçomMatch</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
 

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -6,5 +6,5 @@
     </linearGradient>
   </defs>
   <rect width="200" height="50" rx="8" fill="white"/>
-  <text x="100" y="32" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="url(#grad)">FreeAllin</text>
+  <text x="100" y="32" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="url(#grad)">GarçomMatch</text>
 </svg>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,11 +12,11 @@ const Footer = () => {
                 <span className="text-white font-bold text-sm"><img src="/public/favicon.ico" /></span>
               </div>
               {/* Show text on larger screens and logo on mobile */}
-              <span className="hidden sm:block text-xl font-bold">FreeAllin</span>
+              <span className="hidden sm:block text-xl font-bold">GarçomMatch</span>
               <img
                 src="/logo.png"
                 srcSet="/logo.svg 2x"
-                alt="FreeAllin logo"
+                alt="GarçomMatch logo"
                 className="block sm:hidden h-8 w-auto"
               />
             </div>


### PR DESCRIPTION
## Summary
- replace leftover FreeAllin branding with GarçomMatch

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6851bff65364832ea7d1b9524c5e0b76