### PR TITLE
Add color branding to job pages

### DIFF
--- a/src/components/JobsPreviewSection.tsx
+++ b/src/components/JobsPreviewSection.tsx
@@ -56,7 +56,7 @@ const JobsPreviewSection = () => {
   const navigate = useNavigate();
 
   return (
-    <section className="py-16 bg-gray-50">
+    <section className="py-16 bg-gradient-to-br from-blue-50 via-purple-50 to-white">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-8">
           <h2 className="text-3xl font-bold text-gray-900 mb-2">Vagas Disponíveis</h2>

--- a/src/pages/BrowseJobs.tsx
+++ b/src/pages/BrowseJobs.tsx
@@ -146,7 +146,7 @@ const BrowseJobs = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-white">
       <Header />
       
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-8">

--- a/src/pages/EstablishmentDashboard.tsx
+++ b/src/pages/EstablishmentDashboard.tsx
@@ -74,7 +74,7 @@ const EstablishmentDashboard = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-white">
       <Header />
       
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/src/pages/FreelancerDashboard.tsx
+++ b/src/pages/FreelancerDashboard.tsx
@@ -77,7 +77,7 @@ const FreelancerDashboard = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-purple-50 to-white">
       <Header />
       
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-8">


### PR DESCRIPTION
## Summary
- set gradient background for job listings section
- apply same branding to Browse Jobs and dashboards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854669bd5d0832e934658fbc79cfd18